### PR TITLE
Add ssl with letsencrypt. Update url on frontend + more media queries

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -15,12 +15,12 @@ npm --prefix $WEB_DIR run build
 echo -e "-- Building application containers --\n"
 
 if [[ $1 = "full" ]] ; then
-    docker-compose -f docker-compose-staging.yml build --no-cache
+    docker-compose -f docker-compose-ssl.yml build --no-cache
 else
-    docker-compose -f docker-compose-staging.yml build
+    docker-compose -f docker-compose-ssl.yml build
 fi
 
 # Push docker images to dockerhub registry.
-docker-compose -f docker-compose-staging.yml push
+docker-compose -f docker-compose-ssl.yml push
 
 echo -e "\n-- Application containers have been built and pushed --"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -37,15 +37,21 @@ services:
       - webdata:/usr/src/web
 
   nginx:
-    image: sjbitcode/emoji-nginx
+    image: nginx:1.13-alpine
     restart: always
     container_name: nginx
     volumes:
+      - /docker/letsencrypt-docker-nginx/src/production/production-site:/usr/share/nginx/html
+      - /docker/letsencrypt-docker-nginx/src/production/production.conf:/etc/nginx/conf.d/default.conf
+      - /docker/letsencrypt-docker-nginx/src/production/dh-param/dhparam-2048.pem:/etc/ssl/certs/dhparam-2048.pem
+      - /docker-volumes/etc/letsencrypt/live/emoji.sangeeta.io/fullchain.pem:/etc/letsencrypt/live/emoji.sangeeta.io/fullchain.pem
+      - /docker-volumes/etc/letsencrypt/live/emoji.sangeeta.io/privkey.pem:/etc/letsencrypt/live/emoji.sangeeta.io/privkey.pem
       - ./logs:/var/log/nginx
       - appstatic:/usr/src/appstatic
       - webdata:/usr/src/webdata
     ports:
       - "80:80"
+      - "443:443"
     networks:
       - emoji_network
     depends_on:

--- a/docker-compose-ssl.yml
+++ b/docker-compose-ssl.yml
@@ -1,0 +1,53 @@
+version: '3.5'
+
+
+services:
+
+  postgres:
+    image: postgres:9.6.6-alpine
+    container_name: postgres
+    restart: always
+    networks:
+      - emoji_network
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./data/db_backups:/db_backups
+    env_file: ./deploy/secrets/staging.env
+
+  app:
+    image: sjbitcode/emoji-app
+    build: ./app
+    restart: always
+    container_name: app
+    networks:
+      - emoji_network
+    depends_on:
+      - postgres
+    volumes:
+      - ./app:/usr/src/app
+      - ./logs:/usr/src/logs
+      - appstatic:/usr/src/app/static
+    ports:
+      - "8000:8000"
+    env_file: ./deploy/secrets/staging.env
+    command: gunicorn config.wsgi:application -c config/gunicornconfig.py
+
+  web:
+    image: sjbitcode/emoji-web
+    build: ./web
+    container_name: web
+    volumes:
+      - webdata:/usr/src/web
+
+
+volumes: 
+  pgdata:
+  webdata:
+    name: webdata
+  appstatic:
+    name: appstatic
+
+
+networks:
+  emoji_network:
+

--- a/letsencrypt/certbot-live.sh
+++ b/letsencrypt/certbot-live.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+sudo docker run -it --rm \
+-v /docker-volumes/etc/letsencrypt:/etc/letsencrypt \
+-v /docker-volumes/var/lib/letsencrypt:/var/lib/letsencrypt \
+-v /docker/letsencrypt-docker-nginx/src/letsencrypt/letsencrypt-site:/data/letsencrypt \
+-v "/docker-volumes/var/log/letsencrypt:/var/log/letsencrypt" \
+certbot/certbot \
+certonly --webroot \
+--email contact@sangeeta.io --agree-tos --no-eff-email \
+--webroot-path=/data/letsencrypt \
+-d emoji.sangeeta.io

--- a/letsencrypt/certbot-renew.sh
+++ b/letsencrypt/certbot-renew.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# This script placed in /etc/cron.monthly to run every month.
+sudo docker run --rm -it --name certbot \
+-v "/docker-volumes/etc/letsencrypt:/etc/letsencrypt" \
+-v "/docker-volumes/var/lib/letsencrypt:/var/lib/letsencrypt" \
+-v "/docker/letsencrypt-docker-nginx/src/letsencrypt/letsencrypt-site:/data/letsencrypt" \
+-v "/docker-volumes/var/log/letsencrypt:/var/log/letsencrypt" \
+certbot/certbot renew --quiet

--- a/letsencrypt/certbot-staging.sh
+++ b/letsencrypt/certbot-staging.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+sudo docker run -it --rm \
+-v /docker-volumes/etc/letsencrypt:/etc/letsencrypt \
+-v /docker-volumes/var/lib/letsencrypt:/var/lib/letsencrypt \
+-v /docker/letsencrypt-docker-nginx/src/letsencrypt/letsencrypt-site:/data/letsencrypt \
+-v "/docker-volumes/var/log/letsencrypt:/var/log/letsencrypt" \
+certbot/certbot \
+certonly --webroot \
+--register-unsafely-without-email --agree-tos \
+--webroot-path=/data/letsencrypt \
+--staging \
+-d emoji.sangeeta.io

--- a/letsencrypt/docker-compose.yml
+++ b/letsencrypt/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.5'
+
+services:
+  letsencrypt-nginx-container:
+    container_name: 'letsencrypt-nginx-container'
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./letsencrypt-site:/usr/share/nginx/html
+    networks:
+      - docker-network
+
+networks:
+  docker-network:
+    driver: bridge
+

--- a/letsencrypt/letsencrypt-site/index.html
+++ b/letsencrypt/letsencrypt-site/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Let's Encrypt First Time Cert Issue Site</title>
+</head>
+
+<body>
+  <h1>Oh, hai there!</h1>
+  <p>This is the temporary site that will be used for the very first time the SSL certificates are issued by Let's Encrypt's certbot.</p>
+</body>
+</html>

--- a/letsencrypt/nginx.conf
+++ b/letsencrypt/nginx.conf
@@ -1,0 +1,13 @@
+server {
+  listen 80;
+  listen [::]:80;
+  server_name test.sangeeta.io;
+
+  location ~ /.well-known/acme-challenge {
+    allow all;
+    root /usr/share/nginx/html;
+  }
+
+  root /usr/share/nginx/html;
+  index index.html;
+}

--- a/production/production-site/index.html
+++ b/production/production-site/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Let's Encrypt First Time Cert Issue Site</title>
+</head>
+
+<body>
+  <h1>Oh, hai there!</h1>
+  <p>This is the temporary site that will be used for the very first time the SSL certificates are issued by Let's Encrypt's certbot.</p>
+</body>
+</html>

--- a/production/production.conf
+++ b/production/production.conf
@@ -1,0 +1,73 @@
+upstream app_server {
+    server app:8000;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    charset utf-8;
+    include /etc/nginx/mime.types;
+    server_name emoji.sangeeta.io;
+
+    location ^~ /.well-known/acme-challenge {
+        root /usr/share/nginx/html;
+        default_type text_plain;
+        allow all;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name emoji.sangeeta.io;
+
+    ssl_certificate /etc/letsencrypt/live/emoji.sangeeta.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/emoji.sangeeta.io/privkey.pem;
+    ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_timeout 5m;
+    
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8;
+    resolver_timeout 5s;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+
+    location ^~ /.well-known/acme-challenge {
+        root /usr/share/nginx/html;
+        default_type text/plain;
+        allow all;
+    }
+
+    # Vue app
+    location / {
+        root /usr/src/webdata;
+        try_files $uri $uri/ /index.html;
+
+    }
+
+    # Django static files
+    location /api/static {
+        alias /usr/src/appstatic/;
+    }
+
+    # Django app
+    location /api {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header X-Script-Name /api;
+        proxy_pass http://app_server;
+    }
+}

--- a/web/src/components/Api.vue
+++ b/web/src/components/Api.vue
@@ -15,10 +15,23 @@
                                     </h1>
 
                                     <span class="description">
-                                        The base url is <span class="code">{{ baseUrl }}</span>.<br>
-                                        All requests are GET requests.<br>
-                                        All requests use the <span class="code">application/json</span>
-                                        content-type.<br>
+                                        <ul>
+                                            <li>
+                                                <i class="fas fa-caret-right"></i> The base url is <span class="code">{{ baseUrl }}</span>.
+                                            </li>
+
+                                            <li>
+                                                <i class="fas fa-caret-right"></i> All requests are <span class="code">GET</span> requests and all API access is over <span class="code">https</span>.
+                                            </li>
+
+                                            <li>
+                                                <i class="fas fa-caret-right"></i> All data is sent with the <span class="code">application/json</span> content-type.
+                                            </li>
+
+                                            <li>
+                                                <i class="fas fa-caret-right"></i> This API supports cross-origin HTTP requests, commonly referred to as <span class="code">CORS</span>.
+                                            </li>
+                                        </ul>
                                     </span>
 
                                     <h2 class="heading">
@@ -144,6 +157,10 @@
     margin-top: 10px;
 }
 
+.description {
+    line-height: 2;
+}
+
 .description .code {
     padding: 2px 4px;
     font-size: 90%;
@@ -151,5 +168,19 @@
     border-radius: 4px;
     color: #fff;
     font-family: monospace;
+}
+
+.fa-caret-right {
+    color: #3f1e8a;
+}
+
+@media only screen and (max-width: 768px) {
+    .level-left > .level-item h1.title,
+    .level-left > .level-item h2.heading {
+        text-align: center;
+    }
+    .description > ul li {
+        margin: 20px 0;
+    }
 }
 </style>

--- a/web/src/components/Contact.vue
+++ b/web/src/components/Contact.vue
@@ -89,9 +89,11 @@
 
                                     <div class="panel-block" v-show="active_tab === 'hosting'">
                                         <div class="tags">
+                                            <a href="https://www.vultr.com/" target="_blank" class="tag is-rounded">Vultr</a>
+
                                             <a href="https://aws.amazon.com/s3/" target="_blank" class="tag is-rounded">Amazon Route53</a>
 
-                                            <a href="https://www.vultr.com/" target="_blank" class="tag is-rounded">Vultr</a>
+                                            <a href="https://letsencrypt.org/" target="_blank" class="tag is-rounded">Let's Encrypt</a>
 
                                         </div>
                                     </div>
@@ -184,5 +186,10 @@
 .tag:not(body) {
     background-color: #5f43ad;
     color: white;
+}
+
+.tags {
+    display: unset !important;
+    flex-wrap: unset !important;
 }
 </style>

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -83,7 +83,7 @@ if (process.env.NODE_ENV === 'production') {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: '"production"',
-        API_URL: '"http://emoji.sangeeta.io/api/v1"',
+        API_URL: '"https://emoji.sangeeta.io/api/v1"',
       }
     }),
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
- Followed [this article](https://www.humankode.com/ssl/how-to-set-up-free-ssl-certificates-from-lets-encrypt-using-docker-and-nginx) and [this course](https://httpswithletsencrypt.com/?utm_source=nj&utm_medium=website&utm_campaign=/courses/) to set up Let's Encrypt ssl certificate with Docker and nginx.
- Modified docker-compose-prod.yml to use mappings for certificates, DH param file, modified nginx conf files stored on server.
- Modified docker-compose-staging.yml file (renamed to docker-compose-ssl.yml) to exclude nginx and only build app, web images.
- Updated API_URL in webpack_config to https version. 
- Added additional media queries to Api and Contact component.

